### PR TITLE
Fix error: Warning: Functions are not valid as a React child.

### DIFF
--- a/src/pages/Home/index.js
+++ b/src/pages/Home/index.js
@@ -4,7 +4,7 @@ import loadable from '@loadable/component';
 import { Loading, ErrorBoundary } from '../../components';
 
 const Home = loadable(() => import('./Home'), {
-  fallback: Loading
+  fallback: <Loading />
 });
 
 export default () => (

--- a/src/pages/UserInfo/index.js
+++ b/src/pages/UserInfo/index.js
@@ -4,7 +4,7 @@ import loadable from '@loadable/component';
 import { Loading, ErrorBoundary } from '../../components';
 
 const UserInfo = loadable(() => import('./UserInfo'), {
-  fallback: Loading
+  fallback: <Loading />
 });
 
 export default () => (


### PR DESCRIPTION
@xD3CODER @wellyshen just fixed another issue which results in the following on page load:

Warning: Functions are not valid as a React child. This may happen if you return a Component instead of <Component /> from render. Or maybe you meant to call this function rather than return it.